### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,7 @@
 import passport from "passport";
 import { Strategy as LocalStrategy } from "passport-local";
 import { Express } from "express";
+import lusca from "lusca";
 import session from "express-session";
 import { scrypt, randomBytes, timingSafeEqual } from "crypto";
 import { promisify } from "util";
@@ -45,6 +46,7 @@ export function setupAuth(app: Express) {
   }
 
   app.use(session(sessionSettings));
+  app.use(lusca.csrf());
   app.use(passport.initialize());
   app.use(passport.session());
 


### PR DESCRIPTION
Potential fix for [https://github.com/pizzarudler/Word-Scramble/security/code-scanning/2](https://github.com/pizzarudler/Word-Scramble/security/code-scanning/2)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides a CSRF middleware that can be easily integrated. We will:
1. Install the `lusca` package.
2. Import the `lusca` package in the `server/auth.ts` file.
3. Add the `lusca.csrf()` middleware to the Express application before the state-changing routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
