### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "ws": "^8.18.0",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.4.0",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -80,6 +81,15 @@ export function serveStatic(app: Express) {
   }
 
   app.use(express.static(distPath));
+
+  // set up rate limiter: maximum of 100 requests per 15 minutes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+
+  // apply rate limiter to all requests
+  app.use(limiter);
 
   // fall through to index.html if the file doesn't exist
   app.use("*", (_req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/pizzarudler/Word-Scramble/security/code-scanning/7](https://github.com/pizzarudler/Word-Scramble/security/code-scanning/7)

To fix the problem, we need to introduce rate limiting to the route handler that performs the file system access. We can use the `express-rate-limit` package to achieve this. The rate limiter will be configured to allow a maximum number of requests within a specified time window. This will help prevent denial-of-service attacks by limiting the rate at which requests are accepted.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server/vite.ts` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the route handler that performs the file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
